### PR TITLE
Docs: add EU Langsmith endpoint

### DIFF
--- a/.env_example
+++ b/.env_example
@@ -1,5 +1,5 @@
 LANGSMITH_TRACING="true"
-LANGSMITH_ENDPOINT="https://api.smith.langchain.com"
+LANGSMITH_ENDPOINT="https://api.smith.langchain.com" # replace with "https://eu.api.smith.langchain.com" if you set your region to EU
 LANGSMITH_API_KEY="<YOUR_API_KEY>"
 LANGSMITH_PROJECT="<YOUR_PROJECT_NAME>"
 OPENAI_API_KEY="<YOUR_API_KEY>"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ This repo is linked to this [research task](https://github.com/BeyondQuality/bey
 1. Get some credit and an API token from https://platform.openai.com/ (€5 should be more than enough)
 2. Get an account at LangSmith: https://smith.langchain.com/ and create a project
 3. Copy `.env_example` and rename it as `.env`(Should be gitignored) 
-4. Add your API keys and project name from LangSmith to your `.env` file
+4. [optional] change the `LANGSMITH_ENDPOINT` value to the EU endpoint if you have set this as your Langsmith data region
+5. Add your API keys and project name from LangSmith to your `.env` file
    
 ### Quickstart (via Docker)
 #### Prerequisites


### PR DESCRIPTION
I included the EU Langsmith endpoint to the readme and .env-example to ease the onboarding (if the wrong region is set a generic HTTP403 error is returned).
